### PR TITLE
Changed ScrollToTop.js

### DIFF
--- a/src/ScrollToTop.js
+++ b/src/ScrollToTop.js
@@ -1,11 +1,12 @@
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
+import Scrollbar from "smooth-scrollbar";
 
 export default function ScrollToTop() {
     const { pathname } = useLocation();
 
     useEffect(() => {
-        window.scrollTo(0, 0);
+      Scrollbar.get(document.body).scrollTo(0, 0);
     }, [pathname]);
 
     return null;


### PR DESCRIPTION
The window.scrollTo(0,0) is not accessible as it is overridden due to the usage of smooth-scrollbar npm package. 
Now the issue is fixed as per the documentation of the npm package.